### PR TITLE
Move Timber class check to the top of the file

### DIFF
--- a/lib/timber.php
+++ b/lib/timber.php
@@ -2,6 +2,19 @@
 use Roots\Sage\Setup;
 
 /**
+ * Check if Timber is activated
+ */
+
+if ( ! class_exists( 'Timber' ) ) {
+
+    add_action( 'admin_notices', function() {
+        echo '<div class="error"><p>Timber not activated. Make sure you activate the plugin in <a href="' . esc_url( admin_url( 'plugins.php#timber' ) ) . '">' . esc_url( admin_url( 'plugins.php' ) ) . '</a></p></div>';
+    } );
+    return;
+
+}
+
+/**
  * Timber
  */
 
@@ -31,18 +44,3 @@ class TwigSageTheme extends TimberSite {
     }
 }
 new TwigSageTheme();
-
-/**
- * Timber
- *
- * Check if Timber is activated
- */
-
-if ( ! class_exists( 'Timber' ) ) {
-
-    add_action( 'admin_notices', function() {
-        echo '<div class="error"><p>Timber not activated. Make sure you activate the plugin in <a href="' . esc_url( admin_url( 'plugins.php#timber' ) ) . '">' . esc_url( admin_url( 'plugins.php' ) ) . '</a></p></div>';
-    } );
-    return;
-
-}


### PR DESCRIPTION
The check is supossed to happen before the attempt to use. Also this
way the error message displays as it should.
