### PR TITLE
Improved display_sidebar conditional markup

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -8,18 +8,24 @@
         {% include 'templates/header.twig' %}
 
         <div class="wrap container" role="document">
-            <div class="content row">
-                <main class="col-md-8">
-                    {% block content %}{% endblock %}
-                </main>
-                {% if display_sidebar %}
+            {% if display_sidebar %}
+                <div class="content row">
+                    <main class="col-md-8">
+                        {% block content %}{% endblock %}
+                    </main>
                     <aside class="sidebar col-md-4">
                         {% block sidebar %}
                             {% include 'templates/sidebar.twig' %}
                         {% endblock %}
                     </aside>
-                {% endif %}
-            </div>
+                </div>
+            {% else %}
+                <div class="content">
+                    <main>
+                        {% block content %}{% endblock %}
+                    </main>
+                </div>
+            {% endif %}
         </div>
 
         {% include 'templates/footer.twig' %}


### PR DESCRIPTION
Previously, the base template didn't conditionalize the `col-md-8` classes on the main content area, resulting in a blank sidebar area remaining in the layout even when `display_sidebar` evaluated to `false`.

This change allows full-width layouts for non-sidebar pages.
