### PR TITLE
Improved display_sidebar conditional markup

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -8,18 +8,30 @@
         {% include 'templates/header.twig' %}
 
         <div class="wrap container" role="document">
-            <div class="content row">
-                <main class="col-md-8">
-                    {% block content %}{% endblock %}
-                </main>
-                {% if display_sidebar %}
+            {% if display_sidebar %}
+                <div class="content row">
+                    <main class="col-md-8">
+            {% else %}
+                <div class="content">
+                    <main>
+            {% endif %}
+
+
+            {% block content %}{% endblock %}
+
+
+            {% if display_sidebar %}
+                    </main>
                     <aside class="sidebar col-md-4">
                         {% block sidebar %}
                             {% include 'templates/sidebar.twig' %}
                         {% endblock %}
                     </aside>
-                {% endif %}
-            </div>
+                </div>
+            {% else %}
+                    </main>
+                </div>
+            {% endif %}
         </div>
 
         {% include 'templates/footer.twig' %}

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -8,30 +8,18 @@
         {% include 'templates/header.twig' %}
 
         <div class="wrap container" role="document">
-            {% if display_sidebar %}
-                <div class="content row">
-                    <main class="col-md-8">
-            {% else %}
-                <div class="content">
-                    <main>
-            {% endif %}
-
-
-            {% block content %}{% endblock %}
-
-
-            {% if display_sidebar %}
-                    </main>
-                    <aside class="sidebar col-md-4">
-                        {% block sidebar %}
-                            {% include 'templates/sidebar.twig' %}
-                        {% endblock %}
-                    </aside>
-                </div>
-            {% else %}
-                    </main>
-                </div>
-            {% endif %}
+            <div class="content {% if display_sidebar %}row{% endif %}">
+                <main class="{% if display_sidebar %}col-md-8{% endif %}">
+                    {% block content %}{% endblock %}
+                </main>
+                {% if display_sidebar %}
+                <aside class="sidebar col-md-4">
+                    {% block sidebar %}
+                        {% include 'templates/sidebar.twig' %}
+                    {% endblock %}
+                </aside>
+                {% endif %}
+            </div>
         </div>
 
         {% include 'templates/footer.twig' %}


### PR DESCRIPTION
If `display_sidebar` evaluates to `false`, the sidebar block should be hidden and the main content area should fill the width of the container. However, the base template had previously left the `col-md-8` width class in place regardless of the value of `display_sidebar`.

Page layouts now only apply column classes if `display_sidebar` evaluates to `true`.
