### PR TITLE
Use HTTPS for packagist url so Composer update doesn't fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     }
   ]
 }


### PR DESCRIPTION
`composer update` now fails with non-https urls by default.  

Super minor change, but as long as the https url is available it will work on a new install without having to change Composer config to allow non-secure urls.

Thanks!
